### PR TITLE
trinity-desktop-ci: Remove wine dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,6 @@ RUN apt-get update && apt-get install -y git python \
     libudev-dev libusb-1.0-0-dev && \
     rm -rf /var/lib/apt/lists/*
 
-
-# Install wine (needed for Windows build)
-RUN dpkg --add-architecture i386 && \
-    wget -nc https://dl.winehq.org/wine-builds/winehq.key && \
-    apt-key add winehq.key && \
-    apt-add-repository https://dl.winehq.org/wine-builds/debian/ && \
-    apt-get update && \
-    apt-get install --install-recommends -y winehq-stable && \
-    rm -rf /var/lib/apt/lists/*
-
 # Install appimagetool (needed for Linux build)
 RUN wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage && \
     chmod a+x appimagetool-x86_64.AppImage


### PR DESCRIPTION
Wine is no longer needed since the Windows app is built on its own VM