### PR TITLE
Create trinity-shared-ci image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:10.18-stretch
+
+# Build and install OpenSSL 1.0.2k
+# Based on https://github.com/realm/realm-js/blob/master/Dockerfile
+RUN curl -SL https://www.openssl.org/source/openssl-1.0.2k.tar.gz | tar -zxC / && \
+    cd openssl-1.0.2k && \
+    ./Configure -DPIC -fPIC -fvisibility=hidden -fvisibility-inlines-hidden \
+    no-zlib-dynamic no-dso linux-x86_64 --prefix=/usr && make && make install_sw && \
+    cd .. && rm -rf openssl-1.0.2k.tar.gz
+
+# Use our version of OpenSSL instead of the Debian-provided one
+ENV PATH "/usr/local/ssl:$PATH"
+
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-Where are the Dockerfiles? Look into the branches.


### PR DESCRIPTION
Please create and change base branch to `trinity-shared-ci` before merging (I don't have sufficient permissions to do this)

Prerequisite: https://github.com/iotaledger/ci-pipelines/pull/63